### PR TITLE
Bump STAC version from 0.9.0 to 1.0.0-beta.1

### DIFF
--- a/master/atmosphere/catalog.json
+++ b/master/atmosphere/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "atmosphere",
     "title": "Pangeo Atmospheric Science Dataset Catalog",
     "description": "",

--- a/master/atmosphere/era5_hourly_reanalysis_single_levels_sa/collection.json
+++ b/master/atmosphere/era5_hourly_reanalysis_single_levels_sa/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "era5_hourly_reanalysis_single_levels_sa",
     "title": "ERA5 hourly estimates of variables on single levels",

--- a/master/atmosphere/gmet_v1/collection.json
+++ b/master/atmosphere/gmet_v1/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "gmet_v1",
     "title": "Full GMET version 1 (Newman) met ensemble in zarr format",

--- a/master/atmosphere/gpcp_cdr_daily_v1_3/collection.json
+++ b/master/atmosphere/gpcp_cdr_daily_v1_3/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "gpcp_cdr_daily_v1_3",
     "title": "3D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling",

--- a/master/atmosphere/sam_ngaqua_qobs_eqx_2d/collection.json
+++ b/master/atmosphere/sam_ngaqua_qobs_eqx_2d/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "sam_ngaqua_qobs_eqx_2d",
     "title": "2D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling",

--- a/master/atmosphere/sam_ngaqua_qobs_eqx_3d/collection.json
+++ b/master/atmosphere/sam_ngaqua_qobs_eqx_3d/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "sam_ngaqua_qobs_eqx_3d",
     "title": "3D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling",

--- a/master/atmosphere/trmm_3b42rt/collection.json
+++ b/master/atmosphere/trmm_3b42rt/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "trmm_3b42rt",
     "title": "Near real time rainfall estimates from NASA's Tropical Rainfall Measuring Mission",

--- a/master/atmosphere/wrf50_erai/collection.json
+++ b/master/atmosphere/wrf50_erai/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "wrf50_erai",
     "title": "Daily meteorology from 50km WRF simulation forced with ERA-Interim",

--- a/master/catalog.json
+++ b/master/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "master",
     "title": "Pangeo Master Data Catalog",
     "description": "",

--- a/master/climate/GFDL_CM2_6/collection.json
+++ b/master/climate/GFDL_CM2_6/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6",
     "title": "NOAA-GFDL CM2.6 in Google Cloud Storage",

--- a/master/climate/catalog.json
+++ b/master/climate/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "climate",
     "title": "Pangeo Climate Dataset Catalog. Include model ensembles such as CMIP6 and LENS.",
     "description": "",

--- a/master/climate/cmip6_gcs/collection.json
+++ b/master/climate/cmip6_gcs/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "cmip6_gcs",
     "title": "CMIP6 in Google Cloud Storage",

--- a/master/climate/tracmip/collection.json
+++ b/master/climate/tracmip/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "tracmip",
     "title": "TRACMIP in Pangeo Google Cloud Storage",

--- a/master/hydro/camels/attributes_aws/collection.json
+++ b/master/hydro/camels/attributes_aws/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "attributes_aws",
     "title": "Camels Attributes",

--- a/master/hydro/camels/basin_mean_forcing_aws/collection.json
+++ b/master/hydro/camels/basin_mean_forcing_aws/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "basin_mean_forcing_aws",
     "title": "Camels Basin Mean Forcing",

--- a/master/hydro/camels/basin_mean_forcing_gcp/collection.json
+++ b/master/hydro/camels/basin_mean_forcing_gcp/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "basin_mean_forcing_gcp",
     "title": "Camels Basin Mean Forcing",

--- a/master/hydro/camels/catalog.json
+++ b/master/hydro/camels/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "camels",
     "title": "Pangeo Camels Dataset Catalog",
     "description": "",

--- a/master/hydro/camels/usgs_streamflow_aws/collection.json
+++ b/master/hydro/camels/usgs_streamflow_aws/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "usgs_streamflow_aws",
     "title": "Camels USGS Streamflow",

--- a/master/hydro/camels/usgs_streamflow_gcp/collection.json
+++ b/master/hydro/camels/usgs_streamflow_gcp/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "usgs_streamflow_gcp",
     "title": "Camels USGS Streamflow",

--- a/master/hydro/catalog.json
+++ b/master/hydro/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "hydro",
     "title": "Pangeo Hydrology Dataset Catalog",
     "description": "",

--- a/master/hydro/cgiar_pet/collection.json
+++ b/master/hydro/cgiar_pet/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "cgiar_pet",
     "title": "Global potential evapotranspiration from CGIAR-CSI",

--- a/master/hydro/hydrosheds_acc/collection.json
+++ b/master/hydro/hydrosheds_acc/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "hydrosheds_acc",
     "title": "Flow accumulation at 3-second resolution",

--- a/master/hydro/hydrosheds_dem/collection.json
+++ b/master/hydro/hydrosheds_dem/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "hydrosheds_dem",
     "title": "Digital Elevation Model (conditioned DEM) at 3-second resolution",

--- a/master/hydro/hydrosheds_dir/collection.json
+++ b/master/hydro/hydrosheds_dir/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "hydrosheds_dir",
     "title": "Drainage directions at 3-second resolution",

--- a/master/hydro/soil_grids_multi_level/collection.json
+++ b/master/hydro/soil_grids_multi_level/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "soil_grids_multi_level",
     "title": "Global gridded soil information in COG format",

--- a/master/hydro/soil_grids_single_level/collection.json
+++ b/master/hydro/soil_grids_single_level/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "soil_grids_single_level",
     "title": "Global gridded soil information in COG format",

--- a/master/ocean/CESM_POP/CESM_POP_hires_RCP8_5/collection.json
+++ b/master/ocean/CESM_POP/CESM_POP_hires_RCP8_5/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "CESM_POP_hires_RCP8_5",
     "title": "NCAR CESM POP model run BRCP85C5CN_ne120_t12_pop62.c13b17.asdphys.001",

--- a/master/ocean/CESM_POP/CESM_POP_hires_control/collection.json
+++ b/master/ocean/CESM_POP/CESM_POP_hires_control/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "CESM_POP_hires_control",
     "title": "NCAR CESM POP model run hybrid_v5_rel04_BC5_ne120_t12_pop62",

--- a/master/ocean/CESM_POP/catalog.json
+++ b/master/ocean/CESM_POP/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "CESM_POP",
     "title": "NCAR CESM Global High Resolution Ocean Model Fields",
     "description": "",

--- a/master/ocean/ECCO_layers/collection.json
+++ b/master/ocean/ECCO_layers/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "ECCO_layers",
     "title": "Rerun of Estimating the Circulation and Climate of the Ocean (ECCO) with the layers package",

--- a/master/ocean/ECCOv4r3/collection.json
+++ b/master/ocean/ECCOv4r3/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "ECCOv4r3",
     "title": "Estimating the Circulation and Climate of the Ocean (ECCO) State Estimate Version 4 Release 3",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_control_ocean",
     "title": "GFDL CM2.6 climate model control run monthly ocean fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_3D/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_3D/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_control_ocean_3D",
     "title": "GFDL CM2.6 climate model control run 5-day-average 3D ocean fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_boundary_flux/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_boundary_flux/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_control_ocean_boundary_flux",
     "title": "GFDL CM2.6 climate model control run monthly ocean boundary flux fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_budgets/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_budgets/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_control_ocean_budgets",
     "title": "GFDL CM2.6 climate model control run monthly ocean budgets fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_surface/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_surface/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_control_ocean_surface",
     "title": "GFDL CM2.6 climate model control run daily ocean surface fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_transport/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_control_ocean_transport/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_control_ocean_transport",
     "title": "GFDL CM2.6 climate model control run monthly ocean transport fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_grid/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_grid/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_grid",
     "title": "GFDL CM2.6 climate model ocean grid",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_one_percent_ocean",
     "title": "GFDL CM2.6 climate model one-percent CO2 increase run monthly ocean fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_3D/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_3D/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_one_percent_ocean_3D",
     "title": "GFDL CM2.6 climate model one-percent CO2 increase run 5-day-average 3D ocean fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_boundary_flux/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_boundary_flux/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_one_percent_ocean_boundary_flux",
     "title": "GFDL CM2.6 climate model one-percent CO2 increase monthly ocean boundary flux fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_budgets/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_budgets/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_one_percent_ocean_budgets",
     "title": "GFDL CM2.6 climate model one-percent CO2 increase monthly ocean budgets fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_surface/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_surface/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_one_percent_ocean_surface",
     "title": "GFDL CM2.6 climate model one-percent CO2 increase ocean surface fields",

--- a/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_transport/collection.json
+++ b/master/ocean/GFDL_CM2_6/GFDL_CM2_6_one_percent_ocean_transport/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GFDL_CM2_6_one_percent_ocean_transport",
     "title": "GFDL CM2.6 climate model one-percent CO2 increase monthly ocean transport fields",

--- a/master/ocean/GFDL_CM2_6/catalog.json
+++ b/master/ocean/GFDL_CM2_6/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "GFDL_CM2_6",
     "title": "GFDL CM2.6 Climate Model Ocean Fields",
     "description": "",

--- a/master/ocean/GODAS/collection.json
+++ b/master/ocean/GODAS/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "GODAS",
     "title": "NCEP Global Ocean Data Assimilation System",

--- a/master/ocean/LLC4320/LLC4320_SSH/collection.json
+++ b/master/ocean/LLC4320/LLC4320_SSH/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "LLC4320_SSH",
     "title": "MITgcm LLC4320 Ocean Simulation Sea Surface Height",

--- a/master/ocean/LLC4320/LLC4320_SSS/collection.json
+++ b/master/ocean/LLC4320/LLC4320_SSS/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "LLC4320_SSS",
     "title": "MITgcm LLC4320 Ocean Simulation Sea Surface Salinity",

--- a/master/ocean/LLC4320/LLC4320_SST/collection.json
+++ b/master/ocean/LLC4320/LLC4320_SST/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "LLC4320_SST",
     "title": "MITgcm LLC4320 Ocean Simulation Sea Surface Temperature",

--- a/master/ocean/LLC4320/LLC4320_SSU/collection.json
+++ b/master/ocean/LLC4320/LLC4320_SSU/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "LLC4320_SSU",
     "title": "MITgcm LLC4320 Ocean Simulation Sea Surface Zonal Velocity",

--- a/master/ocean/LLC4320/LLC4320_SSV/collection.json
+++ b/master/ocean/LLC4320/LLC4320_SSV/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "LLC4320_SSV",
     "title": "MITgcm LLC4320 Ocean Simulation Sea Surface Meridional Velocity",

--- a/master/ocean/LLC4320/LLC4320_grid/collection.json
+++ b/master/ocean/LLC4320/LLC4320_grid/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "LLC4320_grid",
     "title": "MITgcm LLC4320 Ocean Simulation Grid",

--- a/master/ocean/LLC4320/catalog.json
+++ b/master/ocean/LLC4320/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "LLC4320",
     "title": "MITgcm Global LLC4320 Simulations",
     "description": "",

--- a/master/ocean/MEOM_NEMO/NATL60_SSH/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_SSH/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_SSH",
     "title": "Daily outputs of NATL60-CJM165 Sea Surface Height",

--- a/master/ocean/MEOM_NEMO/NATL60_SSH_1/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_SSH_1/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_SSH_1",
     "title": "Daily outputs of NATL60-CJM165 Sea Surface Height",

--- a/master/ocean/MEOM_NEMO/NATL60_SSU/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_SSU/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_SSU",
     "title": "Daily outputs of NATL60-CJM165 Sea Surface Zonal Velocity",

--- a/master/ocean/MEOM_NEMO/NATL60_SSV/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_SSV/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_SSV",
     "title": "Daily outputs of NATL60-CJM165 Sea Surface Meridional Velocity",

--- a/master/ocean/MEOM_NEMO/NATL60_coord/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_coord/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_coord",
     "title": "NEMO NATL60 Ocean Simulation Coordinates and Masks",

--- a/master/ocean/MEOM_NEMO/NATL60_horizontal_grid/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_horizontal_grid/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_horizontal_grid",
     "title": "NEMO NATL60 Ocean Simulation Horizontal Grid",

--- a/master/ocean/MEOM_NEMO/NATL60_vertical_grid/collection.json
+++ b/master/ocean/MEOM_NEMO/NATL60_vertical_grid/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "NATL60_vertical_grid",
     "title": "NEMO NATL60 Ocean Simulation Vertical Grid",

--- a/master/ocean/MEOM_NEMO/catalog.json
+++ b/master/ocean/MEOM_NEMO/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "MEOM_NEMO",
     "title": "NEMO North Atlantic Ocean Model simulations produced at MEOM",
     "description": "",

--- a/master/ocean/MEOM_NEMO/eNATL60_BLB002_SSU/collection.json
+++ b/master/ocean/MEOM_NEMO/eNATL60_BLB002_SSU/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "eNATL60_BLB002_SSU",
     "title": "Hourly outputs of eNATL60-BLB002 (no tides) Sea Surface Zonal Velocity",

--- a/master/ocean/MEOM_NEMO/eNATL60_BLB002_SSV/collection.json
+++ b/master/ocean/MEOM_NEMO/eNATL60_BLB002_SSV/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "eNATL60_BLB002_SSV",
     "title": "Hourly outputs of eNATL60-BLB002 (no tides) Sea Surface Meridional Velocity",

--- a/master/ocean/MEOM_NEMO/eNATL60_BLBT02_SSH/collection.json
+++ b/master/ocean/MEOM_NEMO/eNATL60_BLBT02_SSH/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "eNATL60_BLBT02_SSH",
     "title": "Hourly outputs of eNATL60-BLBT02 (with tides) Sea Surface Height",

--- a/master/ocean/MEOM_NEMO/eNATL60_BLBT02_SSU/collection.json
+++ b/master/ocean/MEOM_NEMO/eNATL60_BLBT02_SSU/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "eNATL60_BLBT02_SSU",
     "title": "Hourly outputs of eNATL60-BLBT02 (with tides) Sea Surface Zonal Velocity",

--- a/master/ocean/MEOM_NEMO/eNATL60_BLBT02_SSV/collection.json
+++ b/master/ocean/MEOM_NEMO/eNATL60_BLBT02_SSV/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "eNATL60_BLBT02_SSV",
     "title": "Hourly outputs of eNATL60-BLBT02 (with tides) Sea Surface Meridional Velocity",

--- a/master/ocean/MEOM_NEMO/eNATL60_grid/collection.json
+++ b/master/ocean/MEOM_NEMO/eNATL60_grid/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "eNATL60_grid",
     "title": "NEMO eNATL60 Ocean Simulation Grid",

--- a/master/ocean/SOSE/collection.json
+++ b/master/ocean/SOSE/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "SOSE",
     "title": "Southern Ocean State Estimate",

--- a/master/ocean/altimetry/al/collection.json
+++ b/master/ocean/altimetry/al/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "al",
     "title": "Altika Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/alg/collection.json
+++ b/master/ocean/altimetry/alg/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "alg",
     "title": "Altika Drifting Phase Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/c2/collection.json
+++ b/master/ocean/altimetry/c2/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "c2",
     "title": "Cryosat-2 Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/catalog.json
+++ b/master/ocean/altimetry/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "altimetry",
     "title": "Radar Altimetry Products",
     "description": "",

--- a/master/ocean/altimetry/e1/collection.json
+++ b/master/ocean/altimetry/e1/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "e1",
     "title": "ERS-1 Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/e1g/collection.json
+++ b/master/ocean/altimetry/e1g/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "e1g",
     "title": "ERS-1 Geodetic Phase Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/e2/collection.json
+++ b/master/ocean/altimetry/e2/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "e2",
     "title": "ERS-2 Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/en/collection.json
+++ b/master/ocean/altimetry/en/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "en",
     "title": "ENVISAT Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/enn/collection.json
+++ b/master/ocean/altimetry/enn/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "enn",
     "title": "ENVISAT Extension Phase Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/g2/collection.json
+++ b/master/ocean/altimetry/g2/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "g2",
     "title": "Geosat Follow On Phase Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/h2/collection.json
+++ b/master/ocean/altimetry/h2/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "h2",
     "title": "Haiyang-2A Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j1/collection.json
+++ b/master/ocean/altimetry/j1/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j1",
     "title": "Jason-1 Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j1g/collection.json
+++ b/master/ocean/altimetry/j1g/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j1g",
     "title": "Jason-1 Geodetic Phase Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j1n/collection.json
+++ b/master/ocean/altimetry/j1n/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j1n",
     "title": "Jason-1 Interleaved Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j2/collection.json
+++ b/master/ocean/altimetry/j2/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j2",
     "title": "OSTSM/Jason-2 Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j2g/collection.json
+++ b/master/ocean/altimetry/j2g/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j2g",
     "title": "OSTSM/Jason-2 Geodetic Phase Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j2n/collection.json
+++ b/master/ocean/altimetry/j2n/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j2n",
     "title": "OSTSM/Jason-2 Interleaved Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/j3/collection.json
+++ b/master/ocean/altimetry/j3/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "j3",
     "title": "Jason-3 Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/s3a/collection.json
+++ b/master/ocean/altimetry/s3a/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "s3a",
     "title": "Sentinel-3A Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/s3b/collection.json
+++ b/master/ocean/altimetry/s3b/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "s3b",
     "title": "Sentinel-3B Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/tp/collection.json
+++ b/master/ocean/altimetry/tp/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "tp",
     "title": "Topex/Poseidon Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/altimetry/tpn/collection.json
+++ b/master/ocean/altimetry/tpn/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "tpn",
     "title": "Topex/Poseidon Interleaved Global Ocean Along track CMEMS Sea Surface Height L3 product",

--- a/master/ocean/catalog.json
+++ b/master/ocean/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "ocean",
     "title": "Pangeo Oceanography Dataset Catalog",
     "description": "",

--- a/master/ocean/cesm_mom6_example/collection.json
+++ b/master/ocean/cesm_mom6_example/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "cesm_mom6_example",
     "title": "CESM MOM6 Ocean Model Example Data",

--- a/master/ocean/channel/MITgcm_channel_flatbottom_02km_run01_phys-mon/collection.json
+++ b/master/ocean/channel/MITgcm_channel_flatbottom_02km_run01_phys-mon/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "MITgcm_channel_flatbottom_02km_run01_phys-mon",
     "title": "MITgcm channel simulations with flat bottom at 2km resolution physics field monthly mean climatology\n",

--- a/master/ocean/channel/MITgcm_channel_flatbottom_02km_run01_phys_snap15D/collection.json
+++ b/master/ocean/channel/MITgcm_channel_flatbottom_02km_run01_phys_snap15D/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "MITgcm_channel_flatbottom_02km_run01_phys_snap15D",
     "title": "MITgcm channel simulations with flat bottom at 2km resolution physics field snapshots every 15 days\n",

--- a/master/ocean/channel/catalog.json
+++ b/master/ocean/channel/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "id": "channel",
     "title": "MITgcm High Resolution Channel Simulations",
     "description": "",

--- a/master/ocean/channel/channel_ridge_resolutions_01km/collection.json
+++ b/master/ocean/channel/channel_ridge_resolutions_01km/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "channel_ridge_resolutions_01km",
     "title": "MITgcm output from a wind and thermally driven channel with a ridge at 1km resolution, and surface forced tracer\n",

--- a/master/ocean/channel/channel_ridge_resolutions_05km/collection.json
+++ b/master/ocean/channel/channel_ridge_resolutions_05km/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "channel_ridge_resolutions_05km",
     "title": "MITgcm output from a wind and thermally driven channel with a ridge at 5km resolution, and surface forced tracer\n",

--- a/master/ocean/channel/channel_ridge_resolutions_20km/collection.json
+++ b/master/ocean/channel/channel_ridge_resolutions_20km/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "channel_ridge_resolutions_20km",
     "title": "MITgcm output from a wind and thermally driven channel with a ridge at 20km resolution, and surface forced tracer\n",

--- a/master/ocean/channel/run_tracers_restored_zarr/collection.json
+++ b/master/ocean/channel/run_tracers_restored_zarr/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "run_tracers_restored_zarr",
     "title": "MITgcm output from a wind and thermally driven channel with a ridge at 5km resolution and interior restored tracers\n",

--- a/master/ocean/sea_surface_height/collection.json
+++ b/master/ocean/sea_surface_height/collection.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "0.9.0",
+    "stac_version": "1.0.0-beta.1",
     "stac_extensions": [],
     "id": "sea_surface_height",
     "title": "sea-surface altimetry data from The Copernicus Marine Environment",


### PR DESCRIPTION
STAC spec has been updated to 1.0.0-beta.1; this updates all catalogs/collections to reflect his update.